### PR TITLE
Remove volumes on stop command

### DIFF
--- a/src/cli/stop.rs
+++ b/src/cli/stop.rs
@@ -16,6 +16,7 @@ impl CliCommand for Stop {
 
         command
             .arg("down")
+            .arg("--volumes")
             .stdout(Stdio::inherit())
             .stderr(Stdio::inherit());
 


### PR DESCRIPTION
#29 

## Checklist
- [x] I didn't over-scope my PR
- [x] My PR title matches the [commit convention](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I did not include breaking changes
- [ ] I included unit tests that cover my changes
- [ ] I added/updated the documentation about my changes
- [x] I made my own code-review before requesting one

## Description of the changes
Add `--volumes` option to `docker-compose down` command.

## Technical highlight/advice
I think this is all you need.
Maybe we should make this optional as well for the `lenra stop` command?
