### PR TITLE
feat: Non root user for app

### DIFF
--- a/src/docker_compose.rs
+++ b/src/docker_compose.rs
@@ -31,6 +31,7 @@ pub const OF_WATCHDOG_PORT: u16 = 8080;
 pub const DEVTOOL_PORT: u16 = 4000;
 pub const MONGO_PORT: u16 = 27017;
 pub const POSTGRES_PORT: u16 = 5432;
+pub const NON_ROOT_USER: &str = "12000";
 
 /// Generates the docker-compose.yml file
 pub async fn generate_docker_compose(
@@ -107,6 +108,7 @@ async fn generate_docker_compose_content(
                             dockerfile: Some(dockerfile.to_str().unwrap().into()),
                             ..Default::default()
                         })),
+                        user: Some(NON_ROOT_USER.into()),
                         // TODO: Add resources management  when managed by the docker-compose-types lib
                         ..Default::default()
                     }),


### PR DESCRIPTION
Closes #15  

## Checklist
- [x] I didn't over-scope my PR
- [x] My PR title matches the [commit convention](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I did not include breaking changes
- [ ] I included unit tests that cover my changes
- [ ] I added/updated the documentation about my changes
- [x] I made my own code-review before requesting one

## Description of the changes
Make the app container run using the user 12000 has is the default non root user in OpenFaaS
