### PR TITLE
ci: Binary in root dir of tar archives

### DIFF
--- a/.github/workflows/build_ci.yml
+++ b/.github/workflows/build_ci.yml
@@ -164,7 +164,7 @@ jobs:
     - name: Zip
       if: ${{ matrix.os != 'windows' }}
       shell: bash
-      run: tar -czf "lenra-${{ matrix.os }}-${{ matrix.arch }}.tar.gz" "target/${{ matrix.target }}/release/lenra${{ matrix.file_extension }}"
+      run: tar -C "target/${{ matrix.target }}/release" -czf "lenra-${{ matrix.os }}-${{ matrix.arch }}.tar.gz" "lenra${{ matrix.file_extension }}"
 
     - name: Upload
       uses: actions/upload-artifact@v3


### PR DESCRIPTION
Closes #128 

## Checklist
- [ ] I didn't over-scope my PR
- [ ] My PR title matches the [commit convention](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] I did not include breaking changes
- [ ] I included unit tests that cover my changes
- [ ] I added/updated the documentation about my changes
- [ ] I made my own code-review before requesting one

## Description of the changes
Make binary artifacts be at the root directory of the tar archives.