### PR TITLE
docs: Remove Nesqwik from default assignment in bug template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -3,7 +3,6 @@ description: Send a bug report
 title: "[Bug]: "
 labels: ["bug", "triage"]
 assignees:
-  - Nesqwik
   - taorepoara
 body:
   - type: markdown


### PR DESCRIPTION
Nothing much to add.
I've done it in the base template on .github project but it seems that this project have its own template files.